### PR TITLE
Don't recommend users of this module to use predictable names for temporary files

### DIFF
--- a/lib/IPTables/ChainMgr.pm
+++ b/lib/IPTables/ChainMgr.pm
@@ -685,8 +685,6 @@ IPTables::ChainMgr - Perl extension for manipulating iptables and ip6tables poli
       'use_ipv6' => 0,         # can set to 1 to force ip6tables usage
       'ipt_rules_file' => '',  # optional file path from
                                # which to read iptables rules
-      'iptout'   => '/tmp/iptables.out',
-      'ipterr'   => '/tmp/iptables.err',
       'debug'    => 0,
       'verbose'  => 0
 


### PR DESCRIPTION
This is a security vulnerability: it allows an attacker on a multi-user
system to set up symlinks to overwrite any file the current user has
write access to.

See https://github.com/mrash/IPTables-Parse/pull/6 .
